### PR TITLE
Automatic dependency updates

### DIFF
--- a/packages/shelf_api/CHANGELOG.md
+++ b/packages/shelf_api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2025-07-30
+### Changed
+- Updated min sdk version to ^3.8.0
+- Updated dependencies
+
 ## [1.3.2] - 2025-03-16
 ### Changed
 - Updated dependencies
@@ -59,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial Release
 
+[1.3.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.2...shelf_api-v1.3.3
 [1.3.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.1...shelf_api-v1.3.2
 [1.3.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.0+1...shelf_api-v1.3.1
 [1.3.0+1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.0...shelf_api-v1.3.0+1

--- a/packages/shelf_api/pubspec.yaml
+++ b/packages/shelf_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api
 description: A package to declare rest API endpoints that generate into shelf handlers.
-version: 1.3.2
+version: 1.3.3
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,7 +10,7 @@ topics:
   - api
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 resolution: workspace
 
 dependencies:
@@ -23,11 +23,11 @@ dependencies:
   shelf_router: ^1.1.4
 
 dev_dependencies:
-  build_runner: ^2.4.15
-  custom_lint: ^0.7.5
-  dart_pre_commit: ^5.4.4
+  build_runner: ^2.5.4
+  custom_lint: ^0.7.6
+  dart_pre_commit: ^5.4.6
   dart_test_tools: ^6.1.1
-  mockito: ^5.4.5
+  mockito: ^5.4.6
   riverpod_generator: ^2.6.5
   stream_channel: ^2.1.4
   test: ^1.25.15

--- a/packages/shelf_api_builder/CHANGELOG.md
+++ b/packages/shelf_api_builder/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2025-07-30
+### Changed
+- Updated min sdk version to ^3.8.0
+- Updated dependencies
+
 ## [1.2.2] - 2025-03-16
 ### Changed
 - Updated dependencies
@@ -51,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.2.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.2...shelf_api_builder-v1.2.3
 [1.2.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.1...shelf_api_builder-v1.2.2
 [1.2.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.0+1...shelf_api_builder-v1.2.1
 [1.2.0+1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.0...shelf_api_builder-v1.2.0+1

--- a/packages/shelf_api_builder/pubspec.yaml
+++ b/packages/shelf_api_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api_builder
 description: A code generator to create RESTful API endpoints to be integrated with shelf.
-version: 1.2.2
+version: 1.2.3
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,7 +10,7 @@ topics:
   - api
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 resolution: workspace
 
 platforms:
@@ -19,24 +19,24 @@ platforms:
   windows:
 
 dependencies:
-  analyzer: ^7.3.0
-  build: ^2.4.2
+  analyzer: ^7.6.0
+  build: ^2.5.4
   build_config: ^1.1.2
   code_builder: ^4.10.1
   meta: ^1.16.0
   path: ^1.9.1
   shelf: ^1.4.2
-  shelf_api: ^1.3.2
+  shelf_api: ^1.3.3
   source_gen: ^2.0.0
-  source_helper: ^1.3.5
+  source_helper: ^1.3.6
 
 dev_dependencies:
-  build_runner: ^2.4.15
-  custom_lint: ^0.7.5
-  dart_pre_commit: ^5.4.4
+  build_runner: ^2.5.4
+  custom_lint: ^0.7.6
+  dart_pre_commit: ^5.4.6
   dart_test_tools: ^6.1.1
   dio: ^5.8.0+1
-  source_gen_test: ^1.1.1
+  source_gen_test: ^1.2.0
   test: ^1.25.15
 
 cider:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: shelf_api_root
 publish_to: none
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 
 workspace:
   - packages/shelf_api


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for shelf_api_root to ^3.8.0
- Settings sdk version for shelf_api to ^3.8.0
- Settings sdk version for shelf_api_builder to ^3.8.0
### Dependency Updates
```

Changed 4 constraints in packages/shelf_api/pubspec.yaml:
  build_runner: ^2.4.15 -> ^2.5.4
  custom_lint: ^0.7.5 -> ^0.7.6
  dart_pre_commit: ^5.4.4 -> ^5.4.6
  mockito: ^5.4.5 -> ^5.4.6

Changed 8 constraints in packages/shelf_api_builder/pubspec.yaml:
  analyzer: ^7.3.0 -> ^7.6.0
  build: ^2.4.2 -> ^2.5.4
  shelf_api: ^1.3.2 -> ^1.3.3
  source_helper: ^1.3.5 -> ^1.3.6
  build_runner: ^2.4.15 -> ^2.5.4
  custom_lint: ^0.7.5 -> ^0.7.6
  dart_pre_commit: ^5.4.4 -> ^5.4.6
  source_gen_test: ^1.1.1 -> ^1.2.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (86.0.0 available)
  analyzer 7.6.0 (8.0.0 available)
  analyzer_plugin 0.13.4 (0.13.5 available)
  build 2.5.4 (3.0.0 available)
  build_resolvers 2.5.4 (3.0.0 available)
  build_runner 2.5.4 (2.6.0 available)
  build_runner_core 9.1.2 (9.2.0 available)
  build_test 3.2.1 (3.3.0 available)
  characters 1.4.0 (1.4.1 available)
  custom_lint 0.7.6 (0.8.0 available)
  custom_lint_builder 0.7.6 (0.8.0 available)
  custom_lint_core 0.7.5 (0.8.0 available)
  dart_test_tools 6.1.1 (6.1.2 available)
  leak_tracker 10.0.9 (11.0.1 available)
  leak_tracker_flutter_testing 3.0.9 (3.0.10 available)
  leak_tracker_testing 3.0.1 (3.0.2 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  meta 1.16.0 (1.17.0 available)
  mockito 5.4.6 (5.5.0 available)
  petitparser 6.1.0 (7.0.0 available)
  source_gen 2.0.0 (3.0.0 available)
  source_gen_test 1.2.0 (1.3.0 available)
  test 1.25.15 (1.26.3 available)
  test_api 0.7.4 (0.7.7 available)
  test_core 0.6.8 (0.6.12 available)
  vector_math 2.1.4 (2.2.0 available)
  vm_service 15.0.0 (15.0.2 available)
  xml 6.5.0 (6.6.0 available)
No dependencies changed.
28 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
