### PR TITLE
Automatic dependency updates

### DIFF
--- a/packages/shelf_api/CHANGELOG.md
+++ b/packages/shelf_api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2025-10-01
+### Changed
+- Updated min sdk version to ^3.9.0
+- Updated dependencies
+
 ## [1.3.3] - 2025-07-30
 ### Changed
 - Updated min sdk version to ^3.8.0
@@ -64,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial Release
 
+[1.3.4]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.3...shelf_api-v1.3.4
 [1.3.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.2...shelf_api-v1.3.3
 [1.3.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.1...shelf_api-v1.3.2
 [1.3.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.0+1...shelf_api-v1.3.1

--- a/packages/shelf_api/pubspec.yaml
+++ b/packages/shelf_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api
 description: A package to declare rest API endpoints that generate into shelf handlers.
-version: 1.3.3
+version: 1.3.4
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,27 +10,27 @@ topics:
   - api
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.9.0
 resolution: workspace
 
 dependencies:
-  dio: ^5.8.0+1
+  dio: ^5.9.0
   meta: ^1.16.0
-  riverpod: ^2.6.1
-  riverpod_annotation: ^2.6.1
+  riverpod: ^3.0.1
+  riverpod_annotation: ^3.0.1
   rxdart: ^0.28.0
   shelf: ^1.4.2
   shelf_router: ^1.1.4
 
 dev_dependencies:
-  build_runner: ^2.5.4
-  custom_lint: ^0.7.6
-  dart_pre_commit: ^5.4.7
-  dart_test_tools: ^6.1.1
-  mockito: ^5.4.6
-  riverpod_generator: ^2.6.5
+  build_runner: ^2.7.1
+  custom_lint: ^0.8.0
+  dart_pre_commit: ^6.0.0
+  dart_test_tools: ^6.2.3+1
+  mockito: ^5.5.0
+  riverpod_generator: ^3.0.1
   stream_channel: ^2.1.4
-  test: ^1.25.15
+  test: ^1.26.2
 
 cider:
   link_template:

--- a/packages/shelf_api_builder/CHANGELOG.md
+++ b/packages/shelf_api_builder/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2025-10-01
+### Changed
+- Updated min sdk version to ^3.9.0
+- Updated dependencies
+
 ## [1.2.3] - 2025-07-30
 ### Changed
 - Updated min sdk version to ^3.8.0
@@ -56,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.2.4]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.3...shelf_api_builder-v1.2.4
 [1.2.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.2...shelf_api_builder-v1.2.3
 [1.2.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.1...shelf_api_builder-v1.2.2
 [1.2.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.0+1...shelf_api_builder-v1.2.1

--- a/packages/shelf_api_builder/pubspec.yaml
+++ b/packages/shelf_api_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api_builder
 description: A code generator to create RESTful API endpoints to be integrated with shelf.
-version: 1.2.3
+version: 1.2.4
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,7 +10,7 @@ topics:
   - api
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.9.0
 resolution: workspace
 
 platforms:
@@ -20,24 +20,24 @@ platforms:
 
 dependencies:
   analyzer: ^7.6.0
-  build: ^2.5.4
-  build_config: ^1.1.2
-  code_builder: ^4.10.1
+  build: ^3.1.0
+  build_config: ^1.2.0
+  code_builder: ^4.11.0
   meta: ^1.16.0
   path: ^1.9.1
   shelf: ^1.4.2
-  shelf_api: ^1.3.3
-  source_gen: ^2.0.0
-  source_helper: ^1.3.6
+  shelf_api: ^1.3.4
+  source_gen: ^3.1.0
+  source_helper: ^1.3.8
 
 dev_dependencies:
-  build_runner: ^2.5.4
-  custom_lint: ^0.7.6
-  dart_pre_commit: ^5.4.7
-  dart_test_tools: ^6.1.1
-  dio: ^5.8.0+1
-  source_gen_test: ^1.2.0
-  test: ^1.25.15
+  build_runner: ^2.7.1
+  custom_lint: ^0.8.0
+  dart_pre_commit: ^6.0.0
+  dart_test_tools: ^6.2.3+1
+  dio: ^5.9.0
+  source_gen_test: ^1.3.2
+  test: ^1.26.2
 
 cider:
   link_template:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: shelf_api_root
 publish_to: none
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.9.0
 
 workspace:
   - packages/shelf_api


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for shelf_api_root to ^3.9.0
- Settings sdk version for shelf_api to ^3.9.0
- Settings sdk version for shelf_api_builder to ^3.9.0
### Dependency Updates
```

Changed 10 constraints in packages/shelf_api/pubspec.yaml:
  riverpod: ^2.6.1 -> ^3.0.1
  riverpod_annotation: ^2.6.1 -> ^3.0.1
  custom_lint: ^0.7.6 -> ^0.8.0
  dart_pre_commit: ^5.4.7 -> ^6.0.0
  riverpod_generator: ^2.6.5 -> ^3.0.1
  dio: ^5.8.0+1 -> ^5.9.0
  build_runner: ^2.5.4 -> ^2.7.1
  dart_test_tools: ^6.1.1 -> ^6.2.3+1
  mockito: ^5.4.6 -> ^5.5.0
  test: ^1.25.15 -> ^1.26.2

Changed 13 constraints in packages/shelf_api_builder/pubspec.yaml:
  build: ^2.5.4 -> ^3.1.0
  source_gen: ^2.0.0 -> ^3.1.0
  custom_lint: ^0.7.6 -> ^0.8.0
  dart_pre_commit: ^5.4.7 -> ^6.0.0
  build_config: ^1.1.2 -> ^1.2.0
  code_builder: ^4.10.1 -> ^4.11.0
  shelf_api: ^1.3.3 -> ^1.3.4
  source_helper: ^1.3.6 -> ^1.3.8
  build_runner: ^2.5.4 -> ^2.7.1
  dart_test_tools: ^6.1.1 -> ^6.2.3+1
  dio: ^5.8.0+1 -> ^5.9.0
  source_gen_test: ^1.2.0 -> ^1.3.2
  test: ^1.25.15 -> ^1.26.2
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (89.0.0 available)
  analyzer 7.6.0 (8.2.0 available)
+ analyzer_buffer 0.1.10 (0.1.11 available)
  analyzer_plugin 0.13.4 (0.13.8 available)
> build 3.1.0 (was 2.5.4) (4.0.1 available)
> build_config 1.2.0 (was 1.1.2)
> build_resolvers 3.0.3 (was 2.5.4) (3.0.4 available)
> build_runner 2.7.1 (was 2.5.4) (2.9.0 available)
> build_runner_core 9.3.1 (was 9.1.2) (9.3.2 available)
> build_test 3.3.3 (was 3.2.1) (3.4.1 available)
  characters 1.4.0 (1.4.1 available)
> custom_lint 0.8.0 (was 0.7.6) (0.8.1 available)
> custom_lint_builder 0.8.0 (was 0.7.6) (0.8.1 available)
> custom_lint_core 0.8.0 (was 0.7.5) (0.8.1 available)
  custom_lint_visitor 1.0.0+7.7.0 (1.0.0+8.1.1 available)
> dart_pre_commit 6.0.0 (was 5.4.8)
  dart_style 3.1.1 (3.1.2 available)
> dart_test_tools 6.2.3+1 (was 6.1.1)
+ get_it 8.2.0
+ injectable 2.5.2
  material_color_utilities 0.11.1 (0.13.0 available)
  meta 1.16.0 (1.17.0 available)
> mockito 5.5.0 (was 5.4.6) (5.5.1 available)
> riverpod 3.0.1 (was 2.6.1)
> riverpod_analyzer_utils 1.0.0-dev.7 (was 0.5.10)
> riverpod_annotation 3.0.1 (was 2.6.1)
> riverpod_generator 3.0.1 (was 2.6.5)
> source_gen 3.1.0 (was 2.0.0) (4.0.1 available)
> source_gen_test 1.3.2 (was 1.2.0)
> source_helper 1.3.8 (was 1.3.7)
  test 1.26.2 (1.26.3 available)
  test_api 0.7.6 (0.7.7 available)
  test_core 0.6.11 (0.6.12 available)
+ yaml_edit 2.2.2
These packages are no longer being depended on:
- http 1.5.0
Changed 24 dependencies!
22 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
