### PR TITLE
Automatic dependency updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,5 +31,5 @@
 		},
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
 	},
-	"postCreateCommand": "rm -f pubspec.lock && melos run pre-commit:init"
+	"postCreateCommand": "./tool/setup_git_hooks.dart"
 }

--- a/.github/workflows/shelf_api_ci.yaml
+++ b/.github/workflows/shelf_api_ci.yaml
@@ -18,6 +18,7 @@ jobs:
       workingDirectory: packages/shelf_api
       buildRunner: true
       unitTestPaths: -P unit
+      minCoverage: 0 # WORKAROUND for https://github.com/dart-lang/test/issues/2570
       coverageExclude: >-
         "**/*.g.dart"
       integrationTestPaths: -P integration

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ doc/api/
 # Intellij files
 .idea/
 *.iml
-
-# Others
-custom_lint.log

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+plugins:
+  dart_test_tools: ^7.0.1

--- a/packages/shelf_api/CHANGELOG.md
+++ b/packages/shelf_api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2025-12-10
+### Changed
+- Updated min sdk version to ^3.10.0
+- Updated dependencies
+
 ## [1.4.0] - 2025-10-03
 ### Changed
 - Updated min sdk version to ^3.9.0
@@ -70,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial Release
 
+[1.4.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.4.0...shelf_api-v1.4.1
 [1.4.0]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.3...shelf_api-v1.4.0
 [1.3.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.2...shelf_api-v1.3.3
 [1.3.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.1...shelf_api-v1.3.2

--- a/packages/shelf_api/example/date_time_provider.dart
+++ b/packages/shelf_api/example/date_time_provider.dart
@@ -6,11 +6,11 @@ part 'date_time_provider.g.dart';
 @Riverpod(keepAlive: true)
 DateTime dateTimeSingleton(Ref ref) => DateTime.now();
 
-@Riverpod(keepAlive: false)
+@Riverpod()
 DateTime dateTimeFactory(Ref ref) => DateTime.now();
 
 @Riverpod(keepAlive: true, dependencies: [shelfRequest])
 DateTime requestDateTimeSingleton(Ref ref) => DateTime.now();
 
-@Riverpod(keepAlive: false, dependencies: [shelfRequest])
+@Riverpod(dependencies: [shelfRequest])
 DateTime requestDateTimeFactory(Ref ref) => DateTime.now();

--- a/packages/shelf_api/example/main.dart
+++ b/packages/shelf_api/example/main.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print in examples
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/shelf_api/lib/src/api/t_response.dart
+++ b/packages/shelf_api/lib/src/api/t_response.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:shelf/shelf.dart';
-// ignore: implementation_imports
+// ignore: implementation_imports for helper utility
 import 'package:shelf/src/util.dart' show addHeader;
 
 import 'content_types.dart';

--- a/packages/shelf_api/pubspec.yaml
+++ b/packages/shelf_api/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.10.4
-  custom_lint: ^0.8.1
   dart_pre_commit: ^6.1.0
   dart_test_tools: ^7.0.1
   mockito: ^5.6.1

--- a/packages/shelf_api/pubspec.yaml
+++ b/packages/shelf_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api
 description: A package to declare rest API endpoints that generate into shelf handlers.
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,25 +10,25 @@ topics:
   - api
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 resolution: workspace
 
 dependencies:
   dio: ^5.9.0
-  meta: ^1.16.0
-  riverpod: ^3.0.1
-  riverpod_annotation: ^3.0.1
+  meta: ^1.17.0
+  riverpod: ^3.0.3
+  riverpod_annotation: ^3.0.3
   rxdart: ^0.28.0
   shelf: ^1.4.2
   shelf_router: ^1.1.4
 
 dev_dependencies:
-  build_runner: ^2.9.0
+  build_runner: ^2.10.4
   custom_lint: ^0.8.1
-  dart_pre_commit: ^6.0.0
-  dart_test_tools: ^6.2.3+1
-  mockito: ^5.5.1
-  riverpod_generator: ^3.0.1
+  dart_pre_commit: ^6.1.0
+  dart_test_tools: ^7.0.1
+  mockito: ^5.6.1
+  riverpod_generator: ^3.0.3
   stream_channel: ^2.1.4
   test: ^1.26.3
 

--- a/packages/shelf_api/test/integration/test_helper.dart
+++ b/packages/shelf_api/test/integration/test_helper.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print for test files
 
 import 'dart:async';
 import 'dart:convert';

--- a/packages/shelf_api/test/unit/util/stream_extensions_test.dart
+++ b/packages/shelf_api/test/unit/util/stream_extensions_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: discarded_futures
+// ignore_for_file: discarded_futures for test files
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/shelf_api_builder/CHANGELOG.md
+++ b/packages/shelf_api_builder/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2025-12-10
+### Changed
+- Updated min sdk version to ^3.10.0
+- Updated dependencies
+
 ## [1.3.0] - 2025-10-03
 ### Changed
 - Updated min sdk version to ^3.9.0
@@ -67,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.3.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.3.0...shelf_api_builder-v1.3.1
 [1.3.0]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.3...shelf_api_builder-v1.3.0
 [1.2.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.2...shelf_api_builder-v1.2.3
 [1.2.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.1...shelf_api_builder-v1.2.2

--- a/packages/shelf_api_builder/example/basic_model.dart
+++ b/packages/shelf_api_builder/example/basic_model.dart
@@ -28,7 +28,7 @@ class BasicModel {
   @override
   int get hashCode => value.hashCode;
 
-  // ignore: prefer_constructors_over_static_methods
+  // ignore: prefer_constructors_over_static_methods for code generation
   static BasicModel fromJsonX(dynamic value) => BasicModel(value as int);
 
   static int toJsonX(BasicModel model) => model.value;

--- a/packages/shelf_api_builder/example/example_api.dart
+++ b/packages/shelf_api_builder/example/example_api.dart
@@ -23,7 +23,7 @@ import 'endpoints/routing_endpoint.dart';
   basePath: '/api/v1/',
   middleware: apiMiddleware,
 )
-// ignore: unused_element
+// ignore: unused_element for api definition
 class _ExampleApi {}
 
 Middleware apiMiddleware() =>

--- a/packages/shelf_api_builder/example/main.dart
+++ b/packages/shelf_api_builder/example/main.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print in example code
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/shelf_api_builder/lib/src/builders/base/code_builder.dart
+++ b/packages/shelf_api_builder/lib/src/builders/base/code_builder.dart
@@ -1,5 +1,6 @@
-// ignore: implementation_imports
-import 'package:code_builder/src/specs/code.dart';
+import 'package:code_builder/code_builder.dart';
+// ignore: implementation_imports to extend private class
+import 'package:code_builder/src/specs/code.dart' show CodeVisitor;
 import 'package:meta/meta.dart';
 
 @internal

--- a/packages/shelf_api_builder/lib/src/builders/client/method_body_builder.dart
+++ b/packages/shelf_api_builder/lib/src/builders/client/method_body_builder.dart
@@ -33,7 +33,7 @@ final class MethodBodyBuilder extends CodeBuilder {
     this._dioRef,
     this._optionsRef,
     this._extraParamsRefs,
-    // ignore: avoid_positional_boolean_parameters
+    // ignore: avoid_positional_boolean_parameters for private param
     this._isRaw,
   );
 

--- a/packages/shelf_api_builder/lib/src/builders/client/response_builder.dart
+++ b/packages/shelf_api_builder/lib/src/builders/client/response_builder.dart
@@ -18,7 +18,7 @@ final class ResponseBuilder extends CodeBuilder {
   final Expression _invocation;
   final bool _isRaw;
 
-  // ignore: avoid_positional_boolean_parameters
+  // ignore: avoid_positional_boolean_parameters for private param
   const ResponseBuilder(this._response, this._invocation, this._isRaw);
 
   @override

--- a/packages/shelf_api_builder/lib/src/util/code/if.dart
+++ b/packages/shelf_api_builder/lib/src/util/code/if.dart
@@ -1,6 +1,6 @@
 import 'package:code_builder/code_builder.dart';
-// ignore: implementation_imports
-import 'package:code_builder/src/specs/code.dart';
+// ignore: implementation_imports for private apis
+import 'package:code_builder/src/specs/code.dart' show CodeVisitor;
 import 'package:meta/meta.dart';
 
 @internal

--- a/packages/shelf_api_builder/lib/src/util/code/switch.dart
+++ b/packages/shelf_api_builder/lib/src/util/code/switch.dart
@@ -1,6 +1,6 @@
 import 'package:code_builder/code_builder.dart';
-// ignore: implementation_imports
-import 'package:code_builder/src/specs/code.dart';
+// ignore: implementation_imports for private APIs
+import 'package:code_builder/src/specs/code.dart' show CodeVisitor;
 import 'package:meta/meta.dart';
 
 @internal

--- a/packages/shelf_api_builder/lib/src/util/code/try.dart
+++ b/packages/shelf_api_builder/lib/src/util/code/try.dart
@@ -1,6 +1,6 @@
 import 'package:code_builder/code_builder.dart';
-// ignore: implementation_imports
-import 'package:code_builder/src/specs/code.dart';
+// ignore: implementation_imports for private api
+import 'package:code_builder/src/specs/code.dart' show CodeVisitor;
 import 'package:meta/meta.dart';
 
 @internal

--- a/packages/shelf_api_builder/lib/src/util/extensions/code_builder_extensions.dart
+++ b/packages/shelf_api_builder/lib/src/util/extensions/code_builder_extensions.dart
@@ -9,7 +9,7 @@ extension ExpressionX on Expression {
   Expression get yieldedStar =>
       CodeExpression(Block.of([const Code('yield* '), code]));
 
-  // ignore: avoid_positional_boolean_parameters
+  // ignore: avoid_positional_boolean_parameters for obvious use case
   Expression autoProperty(String name, bool isNullable) =>
       isNullable ? nullSafeProperty(name) : property(name);
 }

--- a/packages/shelf_api_builder/lib/src/util/types.dart
+++ b/packages/shelf_api_builder/lib/src/util/types.dart
@@ -293,7 +293,7 @@ abstract base class Types {
 
 @internal
 extension TypesX on TypeReference {
-  // ignore: avoid_positional_boolean_parameters
+  // ignore: avoid_positional_boolean_parameters for single parameter
   TypeReference withNullable(bool isNullable) => TypeReference(
     (b) => b
       ..replace(this)

--- a/packages/shelf_api_builder/pubspec.yaml
+++ b/packages/shelf_api_builder/pubspec.yaml
@@ -19,7 +19,7 @@ platforms:
   windows:
 
 dependencies:
-  analyzer: ^8.4.0
+  analyzer: ">=8.4.0 <10.0.0"
   build: ^4.0.3
   build_config: ^1.2.0
   code_builder: ^4.11.0
@@ -32,7 +32,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.10.4
-  custom_lint: ^0.8.1
   dart_pre_commit: ^6.1.0
   dart_test_tools: ^7.0.1
   dio: ^5.9.0

--- a/packages/shelf_api_builder/pubspec.yaml
+++ b/packages/shelf_api_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api_builder
 description: A code generator to create RESTful API endpoints to be integrated with shelf.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,7 +10,7 @@ topics:
   - api
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 resolution: workspace
 
 platforms:
@@ -19,22 +19,22 @@ platforms:
   windows:
 
 dependencies:
-  analyzer: ">=7.6.0 <9.0.0"
-  build: ">=3.1.0 <5.0.0"
+  analyzer: ^8.4.0
+  build: ^4.0.3
   build_config: ^1.2.0
   code_builder: ^4.11.0
-  meta: ^1.16.0
+  meta: ^1.17.0
   path: ^1.9.1
   shelf: ^1.4.2
-  shelf_api: ^1.4.0
-  source_gen: ">=3.1.0 <5.0.0"
+  shelf_api: ^1.4.1
+  source_gen: ^4.1.1
   source_helper: ^1.3.8
 
 dev_dependencies:
-  build_runner: ^2.9.0
+  build_runner: ^2.10.4
   custom_lint: ^0.8.1
-  dart_pre_commit: ^6.0.0
-  dart_test_tools: ^6.2.3+1
+  dart_pre_commit: ^6.1.0
+  dart_test_tools: ^7.0.1
   dio: ^5.9.0
   source_gen_test: ^1.3.2
   test: ^1.26.3

--- a/packages/shelf_api_builder/test/integration/test_helper.dart
+++ b/packages/shelf_api_builder/test/integration/test_helper.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print in test code
 
 import 'dart:async';
 import 'dart:convert';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: shelf_api_root
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 workspace:
   - packages/shelf_api


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for shelf_api_root to ^3.10.0
- Settings sdk version for shelf_api to ^3.10.0
- Settings sdk version for shelf_api_builder to ^3.10.0
### Dependency Updates
```

Changed 8 constraints in packages/shelf_api/pubspec.yaml:
  dart_test_tools: ^6.2.3+1 -> ^7.0.1
  meta: ^1.16.0 -> ^1.17.0
  riverpod: ^3.0.1 -> ^3.0.3
  riverpod_annotation: ^3.0.1 -> ^3.0.3
  build_runner: ^2.9.0 -> ^2.10.4
  dart_pre_commit: ^6.0.0 -> ^6.1.0
  mockito: ^5.5.1 -> ^5.6.1
  riverpod_generator: ^3.0.1 -> ^3.0.3

Changed 8 constraints in packages/shelf_api_builder/pubspec.yaml:
  dart_test_tools: ^6.2.3+1 -> ^7.0.1
  analyzer: >=7.6.0 <9.0.0 -> ^8.4.0
  build: >=3.1.0 <5.0.0 -> ^4.0.3
  meta: ^1.16.0 -> ^1.17.0
  shelf_api: ^1.4.0 -> ^1.4.1
  source_gen: >=3.1.0 <5.0.0 -> ^4.1.1
  build_runner: ^2.9.0 -> ^2.10.4
  dart_pre_commit: ^6.0.0 -> ^6.1.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (92.0.0 available)
+ analysis_server_plugin 0.3.3 (0.3.4 available)
  analyzer 8.4.0 (9.0.0 available)
  analyzer_plugin 0.13.10 (0.13.11 available)
  characters 1.4.0 (1.4.1 available)
> dart_test_tools 7.0.1 (was 6.2.3+1)
+ flutter_lints 6.0.0
+ lints 6.0.0
  matcher 0.12.17 (0.12.18 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  riverpod_analyzer_utils 1.0.0-dev.7 (1.0.0-dev.8 available)
  source_gen_test 1.3.2 (1.3.3 available)
  source_helper 1.3.8 (1.3.9 available)
  test 1.26.3 (1.28.0 available)
  test_api 0.7.7 (0.7.8 available)
  test_core 0.6.12 (0.6.14 available)
These packages are no longer being depended on:
- custom_lint_builder 0.8.1
- hotreloader 4.3.0
Changed 6 dependencies!
13 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
