### PR TITLE
Automatic dependency updates

### DIFF
--- a/packages/shelf_api/CHANGELOG.md
+++ b/packages/shelf_api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2025-12-31
+### Changed
+- Updated min sdk version to ^3.10.0
+- Updated dependencies
+
 ## [1.4.1] - 2025-12-10
 ### Changed
 - Updated min sdk version to ^3.10.0
@@ -75,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial Release
 
+[1.4.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.4.1...shelf_api-v1.4.2
 [1.4.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.4.0...shelf_api-v1.4.1
 [1.4.0]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.3...shelf_api-v1.4.0
 [1.3.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.2...shelf_api-v1.3.3

--- a/packages/shelf_api/pubspec.yaml
+++ b/packages/shelf_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api
 description: A package to declare rest API endpoints that generate into shelf handlers.
-version: 1.4.1
+version: 1.4.2
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -16,8 +16,8 @@ resolution: workspace
 dependencies:
   dio: ^5.9.0
   meta: ^1.17.0
-  riverpod: ^3.0.3
-  riverpod_annotation: ^3.0.3
+  riverpod: ^3.1.0
+  riverpod_annotation: ^4.0.0
   rxdart: ^0.28.0
   shelf: ^1.4.2
   shelf_router: ^1.1.4
@@ -27,7 +27,7 @@ dev_dependencies:
   dart_pre_commit: ^6.1.0
   dart_test_tools: ^7.0.1
   mockito: ^5.6.1
-  riverpod_generator: ^3.0.3
+  riverpod_generator: ^4.0.0+1
   stream_channel: ^2.1.4
   test: ^1.26.3
 

--- a/packages/shelf_api_builder/CHANGELOG.md
+++ b/packages/shelf_api_builder/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2025-12-31
+### Changed
+- Updated min sdk version to ^3.10.0
+- Updated dependencies
+
 ## [1.3.1] - 2025-12-10
 ### Changed
 - Updated min sdk version to ^3.10.0
@@ -72,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.3.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.3.1...shelf_api_builder-v1.3.2
 [1.3.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.3.0...shelf_api_builder-v1.3.1
 [1.3.0]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.3...shelf_api_builder-v1.3.0
 [1.2.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.2...shelf_api_builder-v1.2.3

--- a/packages/shelf_api_builder/pubspec.yaml
+++ b/packages/shelf_api_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api_builder
 description: A code generator to create RESTful API endpoints to be integrated with shelf.
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -26,7 +26,7 @@ dependencies:
   meta: ^1.17.0
   path: ^1.9.1
   shelf: ^1.4.2
-  shelf_api: ^1.4.1
+  shelf_api: ^1.4.2
   source_gen: ^4.1.1
   source_helper: ^1.3.8
 


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for shelf_api_root to ^3.10.0
- Settings sdk version for shelf_api to ^3.10.0
- Settings sdk version for shelf_api_builder to ^3.10.0
### Dependency Updates
```

Changed 3 constraints in packages/shelf_api/pubspec.yaml:
  riverpod_annotation: ^3.0.3 -> ^4.0.0
  riverpod_generator: ^3.0.3 -> ^4.0.0+1
  riverpod: ^3.0.3 -> ^3.1.0

Changed 1 constraint in packages/shelf_api_builder/pubspec.yaml:
  shelf_api: ^1.4.1 -> ^1.4.2
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (92.0.0 available)
  analysis_server_plugin 0.3.3 (0.3.4 available)
  analyzer 8.4.0 (9.0.0 available)
  analyzer_buffer 0.1.11 (0.2.0 available)
  analyzer_plugin 0.13.10 (0.13.11 available)
  characters 1.4.0 (1.4.1 available)
  matcher 0.12.17 (0.12.18 available)
  material_color_utilities 0.11.1 (0.13.0 available)
> riverpod 3.1.0 (was 3.0.3)
> riverpod_analyzer_utils 1.0.0-dev.8 (was 1.0.0-dev.7)
> riverpod_annotation 4.0.0 (was 3.0.3)
> riverpod_generator 4.0.0+1 (was 3.0.3)
  source_gen_test 1.3.2 (1.3.3 available)
  source_helper 1.3.8 (1.3.9 available)
  test 1.26.3 (1.28.0 available)
  test_api 0.7.7 (0.7.8 available)
  test_core 0.6.12 (0.6.14 available)
These packages are no longer being depended on:
- custom_lint_core 0.8.1
- custom_lint_visitor 1.0.0+8.4.0
- uuid 4.5.2
Changed 7 dependencies!
13 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
