### PR TITLE
Automatic dependency updates

### DIFF
--- a/.github/workflows/shelf_api_builder_ci.yaml
+++ b/.github/workflows/shelf_api_builder_ci.yaml
@@ -16,8 +16,8 @@ jobs:
     uses: Skycoder42/dart_test_tools/.github/workflows/dart.yml@main
     with:
       workingDirectory: packages/shelf_api_builder
+      buildDependencies: shelf_api
       buildRunner: true
-      buildRunnerArgs: --workspace
       panaScoreThreshold: 10
       unitTestPaths: ""
       integrationTestPaths: -P integration

--- a/.github/workflows/shelf_api_builder_ci.yaml
+++ b/.github/workflows/shelf_api_builder_ci.yaml
@@ -16,8 +16,8 @@ jobs:
     uses: Skycoder42/dart_test_tools/.github/workflows/dart.yml@main
     with:
       workingDirectory: packages/shelf_api_builder
-      buildDependencies: shelf_api
       buildRunner: true
+      buildRunnerArgs: --workspace
       panaScoreThreshold: 10
       unitTestPaths: ""
       integrationTestPaths: -P integration

--- a/.github/workflows/shelf_api_ci.yaml
+++ b/.github/workflows/shelf_api_ci.yaml
@@ -17,8 +17,8 @@ jobs:
     with:
       workingDirectory: packages/shelf_api
       buildRunner: true
+      buildRunnerArgs: --workspace
       unitTestPaths: -P unit
-      minCoverage: 0 # WORKAROUND for https://github.com/dart-lang/test/issues/2570
       coverageExclude: >-
         "**/*.g.dart"
       integrationTestPaths: -P integration

--- a/.github/workflows/shelf_api_ci.yaml
+++ b/.github/workflows/shelf_api_ci.yaml
@@ -17,7 +17,6 @@ jobs:
     with:
       workingDirectory: packages/shelf_api
       buildRunner: true
-      buildRunnerArgs: --workspace
       unitTestPaths: -P unit
       coverageExclude: >-
         "**/*.g.dart"

--- a/packages/shelf_api/CHANGELOG.md
+++ b/packages/shelf_api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-02-19
+### Changed
+- Updated min sdk version to ^3.11.0
+- Updated dependencies
+
 ## [1.4.2] - 2025-12-31
 ### Changed
 - Updated min sdk version to ^3.10.0
@@ -80,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial Release
 
+[1.4.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.4.2...shelf_api-v1.4.3
 [1.4.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.4.1...shelf_api-v1.4.2
 [1.4.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.4.0...shelf_api-v1.4.1
 [1.4.0]: https://github.com/Skycoder42/shelf_api/compare/shelf_api-v1.3.3...shelf_api-v1.4.0

--- a/packages/shelf_api/pubspec.yaml
+++ b/packages/shelf_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api
 description: A package to declare rest API endpoints that generate into shelf handlers.
-version: 1.4.2
+version: 1.4.3
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,26 +10,26 @@ topics:
   - api
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 resolution: workspace
 
 dependencies:
-  dio: ^5.9.0
+  dio: ^5.9.1
   meta: ^1.17.0
-  riverpod: ^3.1.0
-  riverpod_annotation: ^4.0.0
+  riverpod: ^3.2.1
+  riverpod_annotation: ^4.0.2
   rxdart: ^0.28.0
   shelf: ^1.4.2
   shelf_router: ^1.1.4
 
 dev_dependencies:
-  build_runner: ^2.10.4
-  dart_pre_commit: ^6.1.0
-  dart_test_tools: ^7.0.1
-  mockito: ^5.6.1
-  riverpod_generator: ^4.0.0+1
+  build_runner: ^2.11.1
+  dart_pre_commit: ^6.1.1+1
+  dart_test_tools: ^7.0.2
+  mockito: ^5.6.3
+  riverpod_generator: ^4.0.3
   stream_channel: ^2.1.4
-  test: ^1.26.3
+  test: ^1.29.0
 
 cider:
   link_template:

--- a/packages/shelf_api_builder/CHANGELOG.md
+++ b/packages/shelf_api_builder/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-02-19
+### Changed
+- Updated min sdk version to ^3.11.0
+- Updated dependencies
+
 ## [1.3.2] - 2025-12-31
 ### Changed
 - Updated min sdk version to ^3.10.0
@@ -77,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.3.3]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.3.2...shelf_api_builder-v1.3.3
 [1.3.2]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.3.1...shelf_api_builder-v1.3.2
 [1.3.1]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.3.0...shelf_api_builder-v1.3.1
 [1.3.0]: https://github.com/Skycoder42/shelf_api/compare/shelf_api_builder-v1.2.3...shelf_api_builder-v1.3.0

--- a/packages/shelf_api_builder/pubspec.yaml
+++ b/packages/shelf_api_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_api_builder
 description: A code generator to create RESTful API endpoints to be integrated with shelf.
-version: 1.3.2
+version: 1.3.3
 homepage: https://github.com/Skycoder42/shelf_api
 topics:
   - server
@@ -10,7 +10,7 @@ topics:
   - api
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 resolution: workspace
 
 platforms:
@@ -19,24 +19,24 @@ platforms:
   windows:
 
 dependencies:
-  analyzer: ">=8.4.0 <10.0.0"
-  build: ^4.0.3
+  analyzer: ^9.0.0
+  build: ^4.0.4
   build_config: ^1.2.0
-  code_builder: ^4.11.0
+  code_builder: ^4.11.1
   meta: ^1.17.0
   path: ^1.9.1
   shelf: ^1.4.2
-  shelf_api: ^1.4.2
-  source_gen: ^4.1.1
-  source_helper: ^1.3.8
+  shelf_api: ^1.4.3
+  source_gen: ^4.2.0
+  source_helper: ^1.3.10
 
 dev_dependencies:
-  build_runner: ^2.10.4
-  dart_pre_commit: ^6.1.0
-  dart_test_tools: ^7.0.1
-  dio: ^5.9.0
-  source_gen_test: ^1.3.2
-  test: ^1.26.3
+  build_runner: ^2.11.1
+  dart_pre_commit: ^6.1.1+1
+  dart_test_tools: ^7.0.2
+  dio: ^5.9.1
+  source_gen_test: ^1.3.4
+  test: ^1.29.0
 
 cider:
   link_template:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: shelf_api_root
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 workspace:
   - packages/shelf_api


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for shelf_api_root to ^3.11.0
- Settings sdk version for shelf_api to ^3.11.0
- Settings sdk version for shelf_api_builder to ^3.11.0
### Dependency Updates
```

Changed 9 constraints in packages/shelf_api/pubspec.yaml:
  dio: ^5.9.0 -> ^5.9.1
  riverpod: ^3.1.0 -> ^3.2.1
  riverpod_annotation: ^4.0.0 -> ^4.0.2
  build_runner: ^2.10.4 -> ^2.11.1
  dart_pre_commit: ^6.1.0 -> ^6.1.1+1
  dart_test_tools: ^7.0.1 -> ^7.0.2
  mockito: ^5.6.1 -> ^5.6.3
  riverpod_generator: ^4.0.0+1 -> ^4.0.3
  test: ^1.26.3 -> ^1.29.0

Changed 12 constraints in packages/shelf_api_builder/pubspec.yaml:
  analyzer: >=8.4.0 <10.0.0 -> ^9.0.0
  build: ^4.0.3 -> ^4.0.4
  code_builder: ^4.11.0 -> ^4.11.1
  shelf_api: ^1.4.2 -> ^1.4.3
  source_gen: ^4.1.1 -> ^4.2.0
  source_helper: ^1.3.8 -> ^1.3.10
  build_runner: ^2.10.4 -> ^2.11.1
  dart_pre_commit: ^6.1.0 -> ^6.1.1+1
  dart_test_tools: ^7.0.1 -> ^7.0.2
  dio: ^5.9.0 -> ^5.9.1
  source_gen_test: ^1.3.2 -> ^1.3.4
  test: ^1.26.3 -> ^1.29.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 92.0.0 (95.0.0 available)
  analysis_server_plugin 0.3.4 (0.3.9 available)
  analyzer 9.0.0 (10.1.0 available)
  analyzer_buffer 0.3.0 (0.3.1 available)
  analyzer_plugin 0.13.11 (0.14.3 available)
  dart_style 3.1.3 (3.1.5 available)
  meta 1.17.0 (1.18.1 available)
No dependencies changed.
7 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
